### PR TITLE
Feature Request: Read TOML Config File

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,14 +101,14 @@ repo-snapshot . --grep "Apache"
 # Shows only the first 15 lines of each file instead of full content
 repo-snapshot . --preview 15
 
-# With a .repopal-config.toml present in the repo root
+# With a .repo-snapshot-config.toml present in the repo root
 repo-snapshot .
 
 # CLI arguments override config values
 repo-snapshot . --output output.md
 ```
 
-TOML configuration file `.repopal-config.toml` example:
+TOML configuration file `.repo-snapshot-config.toml` example:
 
 ```toml
 include = "**/*.ts"

--- a/README.md
+++ b/README.md
@@ -111,7 +111,6 @@ repo-snapshot . --output output.md
 TOML configuration file `.repopal-config.toml` example:
 
 ```toml
-output = "output.txt"
 include = "**/*.ts"
 grep = "Apache"
 output = "output.md"

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ cd repo-snapshot
 ```
 
 1. With `npm`:
+
 ```
 npm install         # Install all dependencies
 npm run build       # Compile TypeScript to dist/
@@ -30,6 +31,7 @@ npm link --global   # Install global CLI
 ```
 
 2. With `pnpm`:
+
 ```
 - If you have not installed pnpm, install it via:
   - macOS: brew install pnpm
@@ -98,8 +100,25 @@ repo-snapshot . --grep "Apache"
 
 # Shows only the first 15 lines of each file instead of full content
 repo-snapshot . --preview 15
+
+# With a .repopal-config.toml present in the repo root
+repo-snapshot .
+
+# CLI arguments override config values
+repo-snapshot . --output output.md
 ```
 
+TOML configuration file `.repopal-config.toml` example:
+
+```toml
+output = "output.txt"
+include = "**/*.ts"
+grep = "Apache"
+output = "output.md"
+# etc...
+```
+
+```
 ## Output
 
 The tool prints repository information, including:
@@ -115,5 +134,6 @@ The tool prints repository information, including:
 
 ## License
 
-This project is licensed under the Apache License 2.0.  
+This project is licensed under the Apache License 2.0.
 See the [LICENSE](LICENSE) file for details.
+```


### PR DESCRIPTION
# Background
It would be helpful if users could utilize a .toml file to enable the repo-snapshot to carry out the same operations in the repository's root directory. 


## Examples of a toml configuration file in the root folder of repo

```toml
include = "**/*.ts"
grep = "Apache"
output = "output.md"
````
Example usages
```Markdown
# With a .repopal-config.toml present in the repo root
repo-snapshot .
or
repo-snapshot
```

log
```bash
❯ repo-snapshot .
not specified paths, using current directory.
Found config file: /Users/phillips/Repo/repo-snapshot/.repo-snapshot.toml
Using options from config: { include: '**/*.ts', grep: 'Apache', output: 'output.md' }
Analyzing paths: [ '/Users/phillips/Repo/repo-snapshot' ]
Output written to output.md
```

## CLI options can override the toml config
```toml
include = "**/*.ts"
grep = "Apache"
output = "output.md"
````
``` Markdown
# CLI arguments override config values
repo-snapshot . --output repo_structure.md
```

log
```
❯ repo-snapshot . --output repo_structure.md
not specified paths, using current directory.
Found config file: /Users/phillips/Repo/repo-snapshot/.repo-snapshot.toml
Using options from config: { include: '**/*.ts', grep: 'Apache', output: 'repo_structure.md' }
Analyzing paths: [ '/Users/phillips/Repo/repo-snapshot' ]
Output written to repo_structure.md
```

close #10 